### PR TITLE
fix: restore --no-open option lost in the remote-aware startup rewrite

### DIFF
--- a/lib/startup.js
+++ b/lib/startup.js
@@ -30,12 +30,13 @@ function webCommand() {
         .name('dsh --profile web')
         .description('Serve the DeepSeek Harness browser UI (remote-capable).')
         .helpOption('-h, --help', 'show this help')
-        .option('--host <host>', 'bind host (0.0.0.0 allowed when the auth plugin is configured)')
-        .option('--port <port>', 'listen port; pass 0 to let the OS pick a free one')
-        .option('--trusted-host <authority...>', 'passthrough for the stock startup\'s browser-trust authorities (kept for CLI compatibility; not consulted by web-auth — sessions cover all remote clients)')
+    .option('--host <host>', 'bind host (0.0.0.0 allowed when the auth plugin is configured)')
+    .option('--no-open', 'do not open the Web UI in the default browser')
+    .option('--port <port>', 'listen port; pass 0 to let the OS pick a free one')        .option('--trusted-host <authority...>', 'passthrough for the stock startup\'s browser-trust authorities (kept for CLI compatibility; not consulted by web-auth — sessions cover all remote clients)')
         .addHelpText('after', `
 Examples:
   dsh --profile web                          serve on the composed host and port
+  dsh --profile web --no-open                serve without opening a browser
   dsh --profile web --host 0.0.0.0 --port 8080   serve on all interfaces (requires auth)
   dsh --profile web auth-reset               reset the web-auth password (invalidates all sessions)
 `);
@@ -117,6 +118,7 @@ export function apply(ctx) {
             program.error(`error: --port must be a number, got ${JSON.stringify(options.port)}`);
         }
         ctx.provide(WEB_STARTUP_SERVICE, {
+            openBrowser: options.open,
             ...options.host !== undefined && { host: options.host },
             ...options.port !== undefined && { port: Number(options.port) },
             trustedHosts: options.trustedHost ?? [],

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -45,6 +45,8 @@ export interface WebStartupValues {
   port?: number
   /** Explicit `--trusted-host` authorities, in argument order (passthrough for downstream consumers; not consulted by web-auth). */
   trustedHosts: string[]
+  /** `--no-open` support: whether the default browser should be opened (default true). */
+  openBrowser?: boolean
 }
 
 /** The web flag family, as commander parsed it. */
@@ -52,6 +54,7 @@ interface WebOptions {
   host?: string
   port?: string
   trustedHost?: string[]
+  open?: boolean
 }
 
 /** Options for the `auth-reset` subcommand. */
@@ -66,11 +69,13 @@ function webCommand(): Command {
     .description('Serve the DeepSeek Harness browser UI (remote-capable).')
     .helpOption('-h, --help', 'show this help')
     .option('--host <host>', 'bind host (0.0.0.0 allowed when the auth plugin is configured)')
+    .option('--no-open', 'do not open the Web UI in the default browser')
     .option('--port <port>', 'listen port; pass 0 to let the OS pick a free one')
     .option('--trusted-host <authority...>', 'passthrough for the stock startup\'s browser-trust authorities (kept for CLI compatibility; not consulted by web-auth — sessions cover all remote clients)')
     .addHelpText('after', `
 Examples:
   dsh --profile web                          serve on the composed host and port
+  dsh --profile web --no-open                serve without opening a browser
   dsh --profile web --host 0.0.0.0 --port 8080   serve on all interfaces (requires auth)
   dsh --profile web auth-reset               reset the web-auth password (invalidates all sessions)
 `)
@@ -154,6 +159,7 @@ export function apply(ctx: Context): void {
       program.error(`error: --port must be a number, got ${JSON.stringify(options.port)}`)
     }
     ctx.provide(WEB_STARTUP_SERVICE, {
+      openBrowser: options.open,
       ...options.host !== undefined && { host: options.host },
       ...options.port !== undefined && { port: Number(options.port) },
       trustedHosts: options.trustedHost ?? [],

--- a/tests/startup.spec.ts
+++ b/tests/startup.spec.ts
@@ -95,7 +95,7 @@ describe('remote web-startup', () => {
     const result = runStartup(ctx, ['--host', '0.0.0.0', '--port', '8080'])
     expect(result.error).toBeUndefined()
     const values = ctx.get(WEB_STARTUP_SERVICE) as WebStartupValues | undefined
-    expect(values).toEqual({ host: '0.0.0.0', port: 8080, trustedHosts: [] })
+    expect(values).toEqual({ host: '0.0.0.0', port: 8080, trustedHosts: [], openBrowser: true })
   })
 
   it('keeps trusted-host parsing', () => {
@@ -105,7 +105,16 @@ describe('remote web-startup', () => {
     expect(values).toEqual({
       host: '127.0.0.1',
       trustedHosts: ['lab.internal', '10.0.0.8'],
+      openBrowser: true,
     })
+  })
+
+  it('accepts --no-open and flips openBrowser to false', () => {
+    const ctx = makeFakeContext()
+    const result = runStartup(ctx, ['--host', '0.0.0.0', '--no-open'])
+    expect(result.error).toBeUndefined()
+    const values = ctx.get(WEB_STARTUP_SERVICE) as WebStartupValues | undefined
+    expect(values).toEqual({ host: '0.0.0.0', trustedHosts: [], openBrowser: false })
   })
 
   it('does not provide webStartup when the auth-reset subcommand is invoked', async () => {


### PR DESCRIPTION
## Problem

The remote-aware replacement for `@deepseek-ai/dsh-web-app/startup` (this plugin) rewrites `webCommand()` to allow `--host 0.0.0.0`, but in doing so it **dropped the `--no-open` flag** that the stock startup defines.

Consequences:
- `dsh web --no-open` fails with `error: unknown option '--no-open'`
- Headless servers cannot suppress the default-browser launch; every `dsh web` start tries to open a browser

## Fix

- Re-add `.option('--no-open', 'do not open the Web UI in the default browser')` to `webCommand()` in both `src/startup.ts` and `lib/startup.js`
- Expose `openBrowser: options.open` via `WEB_STARTUP_SERVICE` so downstream rows (`dsh-web-app` webserver) honor it — commander sets `options.open` to `false` when `--no-open` is passed
- Add `open?: boolean` to `WebOptions` and `openBrowser?: boolean` to `WebStartupValues`
- Update the two existing web-startup tests (`openBrowser: true` default) and add a `--no-open` case

## Verification

- `npm run typecheck` passes
- `npm test`: 35/35 passing (was 34, +1 new `--no-open` case)
- Manual: `dsh web --no-open --port 3099` starts without opening a browser; `--help` lists `--no-open`